### PR TITLE
feat(runtime): change StrEnum stub type to `StrEnum | str`

### DIFF
--- a/src/comfy_script/runtime/factory.py
+++ b/src/comfy_script/runtime/factory.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from enum import Enum
+from enum import Enum, StrEnum
 from pathlib import Path
 import textwrap
 from typing import Any
@@ -337,6 +337,9 @@ class RuntimeFactory:
                         t = type_id
             if c is None:
                 c = t.__name__
+
+            if isinstance(t, type(StrEnum)):
+                c += ' | str'
 
             if optional:
                 assert not output

--- a/src/comfy_script/runtime/factory.py
+++ b/src/comfy_script/runtime/factory.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from enum import Enum, StrEnum
+from enum import Enum
 from pathlib import Path
 import textwrap
 from typing import Any
@@ -338,7 +338,7 @@ class RuntimeFactory:
             if c is None:
                 c = t.__name__
 
-            if isinstance(t, type(StrEnum)):
+            if isinstance(t, type(astutil.StrEnum)):
                 c += ' | str'
 
             if optional:


### PR DESCRIPTION
Hello!

The rationale behind this change is to shut up my typechecker when I'm working with ComfyScript and I'm not able to generate stubs for all known files ahead of time. A good example is when working with Modal, as in [`examples/modal.py`](https://github.com/Chaoses-Ib/ComfyScript/blob/main/examples/modal.py).

One downside to this change is that it also adds '| str' to the enums that *are* completely known ahead of time, like Samplers or Schedulers, since I wasn't sure how to differentiate  them.

Before:
```def __new__(cls, ckpt_name: Checkpoints) -> tuple[Model, Clip, Vae]: ...```
After:
```def __new__(cls, ckpt_name: Checkpoints | str) -> tuple[Model, Clip, Vae]: ...```